### PR TITLE
Support forward & circular references

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,22 +66,26 @@ result = schema.execute(query)
 `graphene_pydantic` supports forward declarations and circular references, but you will need to call the `resolve_placeholders()` method to ensure the types are fully updated before you execute a GraphQL query. For instance:
 
 ``` python
-class FooModel(BaseModel):
-  bar: 'BarModel'
-  
-class BarModel(BaseModel):
-  foo: FooModel
-  
-class Foo(PydanticObjectType):
-  class Meta:
-    model = FooModel
+class NodeModel(BaseModel):
+    id: int
+    name: str
+    labels: 'LabelsModel'
+    
+class LabelsModel(BaseModel):
+    node: NodeModel
+    labels: typing.List[str]
+    
+class Node(PydanticObjectType):
+    class Meta:
+        model = NodeModel
+        
+class Labels(PydanticObjectType):
+    class Meta:
+        model = LabelsModel
+        
 
-class Bar(PydanticObjectType):
-  class Meta:
-    model = BarModel
-
-Foo.resolve_placeholders()  # <-- this line ensures it's resolvable in GraphQL
-Bar.resolve_placeholders()
+Node.resolve_placeholders()  # make the `labels` field work
+Labels.resolve_placeholders()  # make the `node` field work
 ```
 
 ### Full Examples

--- a/README.md
+++ b/README.md
@@ -61,6 +61,28 @@ query = '''
 result = schema.execute(query)
 ```
 
+### Forward declarations and circular references
+
+`graphene_pydantic` supports forward declarations and circular references, but you will need to call the `resolve_placeholders()` method to ensure the types are fully updated before you execute a GraphQL query. For instance:
+
+``` python
+class FooModel(BaseModel):
+  bar: 'BarModel'
+  
+class BarModel(BaseModel):
+  foo: FooModel
+  
+class Foo(PydanticObjectType):
+  class Meta:
+    model = FooModel
+
+class Bar(PydanticObjectType):
+  class Meta:
+    model = BarModel
+
+Foo.resolve_placeholders()  # <-- this line ensures it's resolvable in GraphQL
+Bar.resolve_placeholders()
+```
 
 ### Full Examples
 

--- a/graphene_pydantic/converters.py
+++ b/graphene_pydantic/converters.py
@@ -1,13 +1,17 @@
+import sys
 import collections
-from collections import abc
+import collections.abc
 import typing as T
 import uuid
 import datetime
 import decimal
 import enum
 
+from pydantic import BaseModel, fields
+
 from graphene import Field, Boolean, Enum, Float, Int, List, String, UUID, Union
 from graphene.types.base import BaseType
+from graphene.types.datetime import Date, Time, DateTime
 
 try:
     from graphene.types.decimal import Decimal as GrapheneDecimal
@@ -16,9 +20,6 @@ try:
 except ImportError:  # pragma: no cover
     # graphene 2.1.5+ is required for Decimals
     DECIMAL_SUPPORTED = False
-
-from graphene.types.datetime import Date, Time, DateTime
-from pydantic import fields
 
 from .registry import Registry
 from .util import construct_union_class_name
@@ -44,7 +45,11 @@ def get_attr_resolver(attr_name: str) -> T.Callable:
 
 
 def convert_pydantic_field(
-    field: fields.Field, registry: Registry, **field_kwargs
+    field: fields.Field,
+    registry: Registry,
+    parent_type: T.Type = None,
+    model: T.Type[BaseModel] = None,
+    **field_kwargs,
 ) -> Field:
     """
     Convert a Pydantic model field into a Graphene type field that we can add
@@ -52,7 +57,10 @@ def convert_pydantic_field(
     """
     declared_type = getattr(field, "type_", None)
     field_kwargs.setdefault(
-        "type", convert_pydantic_type(declared_type, field, registry)
+        "type",
+        convert_pydantic_type(
+            declared_type, field, registry, parent_type=parent_type, model=model
+        ),
     )
     field_kwargs.setdefault("required", field.required)
     field_kwargs.setdefault("default_value", field.default)
@@ -66,14 +74,20 @@ def convert_pydantic_field(
 
 
 def convert_pydantic_type(
-    type_: T.Type, field: fields.Field, registry: Registry = None
+    type_: T.Type,
+    field: fields.Field,
+    registry: Registry = None,
+    parent_type: T.Type = None,
+    model: T.Type[BaseModel] = None,
 ) -> BaseType:  # noqa: C901
     """
     Convert a Pydantic type to a Graphene Field type, including not just the
     native Python type but any additional metadata (e.g. shape) that Pydantic
     knows about.
     """
-    graphene_type = find_graphene_type(type_, field, registry)
+    graphene_type = find_graphene_type(
+        type_, field, registry, parent_type=parent_type, model=model
+    )
     if field.shape == fields.Shape.SINGLETON:
         return graphene_type
     elif field.shape in (
@@ -90,7 +104,11 @@ def convert_pydantic_type(
 
 
 def find_graphene_type(
-    type_: T.Type, field: fields.Field, registry: Registry = None
+    type_: T.Type,
+    field: fields.Field,
+    registry: Registry = None,
+    parent_type: T.Type = None,
+    model: T.Type[BaseModel] = None,
 ) -> BaseType:  # noqa: C901
     """
     Map a native Python type to a Graphene-supported Field type, where possible,
@@ -114,17 +132,43 @@ def find_graphene_type(
         return GrapheneDecimal if DECIMAL_SUPPORTED else Float
     elif type_ == int:
         return Int
-    # NOTE: this has to come before any `issubclass()` checks, because annotated
-    # generic types aren't valid arguments to `issubclass`
-    elif hasattr(type_, "__origin__"):
-        return convert_generic_python_type(type_, field, registry)
     elif type_ in (tuple, list, set):
         # TODO: do Sets really belong here?
         return List
-    elif issubclass(type_, enum.Enum):
-        return Enum.from_enum(type_)
     elif registry and registry.get_type_for_model(type_):
         return registry.get_type_for_model(type_)
+    elif registry and isinstance(type_, BaseModel):
+        # If it's a Pydantic model that hasn't yet been wrapped with a ObjectType,
+        # we can put a placeholder in and request that `resolve_placeholders()`
+        # be called to update it.
+        registry.add_placeholder_for_model(type_)
+    # NOTE: this has to come before any `issubclass()` checks, because annotated
+    # generic types aren't valid arguments to `issubclass`
+    elif hasattr(type_, "__origin__"):
+        return convert_generic_python_type(
+            type_, field, registry, parent_type=parent_type, model=model
+        )
+    elif isinstance(type_, T.ForwardRef):
+        # A special case! We have to do a little hackery to try and resolve
+        # the type that this points to, by trying to reference a "sibling" type
+        # to where this was defined so we can get access to that namespace...
+        sibling = model or parent_type
+        if not sibling:
+            raise ConversionError(
+                "Don't know how to convert the Pydantic field "
+                f"{field!r} ({field.type_}), could not resolve "
+                "the forward reference."
+            )
+        module_ns = sys.modules[sibling.__module__].__dict__
+        resolved = type_._evaluate(module_ns, None)
+        # TODO: make this behavior optional. maybe this is a place for the TypeOptions to play a role?
+        if registry:
+            registry.add_placeholder_for_model(resolved)
+        return find_graphene_type(
+            resolved, field, registry, parent_type=parent_type, model=model
+        )
+    elif issubclass(type_, enum.Enum):
+        return Enum.from_enum(type_)
     else:
         raise ConversionError(
             f"Don't know how to convert the Pydantic field {field!r} ({field.type_})"
@@ -132,7 +176,11 @@ def find_graphene_type(
 
 
 def convert_generic_python_type(
-    type_: T.Type, field: fields.Field, registry: Registry = None
+    type_: T.Type,
+    field: fields.Field,
+    registry: Registry = None,
+    parent_type: T.Type = None,
+    model: T.Type[BaseModel] = None,
 ) -> BaseType:  # noqa: C901
     """
     Convert annotated Python generic types into the most appropriate Graphene
@@ -146,7 +194,9 @@ def convert_generic_python_type(
     # decide whether the origin type is a subtype of, say, T.Iterable since typical
     # Python functions like `isinstance()` don't work
     if origin == T.Union:
-        return convert_union_type(type_, field, registry)
+        return convert_union_type(
+            type_, field, registry, parent_type=parent_type, model=model
+        )
     elif origin in (
         T.Tuple,
         T.List,
@@ -155,7 +205,7 @@ def convert_generic_python_type(
         T.Iterable,
         list,
         set,
-    ) or issubclass(origin, abc.Sequence):
+    ) or issubclass(origin, collections.abc.Sequence):
         # TODO: find a better way of divining that the origin is sequence-like
         inner_types = getattr(type_, "__args__", [])
         if not inner_types:  # pragma: no cover  # this really should be impossible
@@ -165,16 +215,26 @@ def convert_generic_python_type(
         # Of course, we can only return a homogeneous type here, so we pick the
         # first of the wrapped types
         inner_type = inner_types[0]
-        return List(find_graphene_type(inner_type, field, registry))
+        return List(
+            find_graphene_type(
+                inner_type, field, registry, parent_type=parent_type, model=model
+            )
+        )
     elif origin in (T.Dict, T.Mapping, collections.OrderedDict, dict) or issubclass(
-        origin, abc.Mapping
+        origin, collections.abc.Mapping
     ):
         raise ConversionError("Don't know how to handle mappings in Graphene")
     else:
         raise ConversionError(f"Don't know how to handle {type_} (generic: {origin})")
 
 
-def convert_union_type(type_: T.Type, field: fields.Field, registry: Registry = None):
+def convert_union_type(
+    type_: T.Type,
+    field: fields.Field,
+    registry: Registry = None,
+    parent_type: T.Type = None,
+    model: T.Type[BaseModel] = None,
+):
     """
     Convert an annotated Python Union type into a Graphene Union.
     """
@@ -184,12 +244,17 @@ def convert_union_type(type_: T.Type, field: fields.Field, registry: Registry = 
         # typing.Union[None, T] -- we can return the Graphene type for T directly
         # since Pydantic will have already parsed it as optional
         native_type = next(x for x in inner_types if x != NONE_TYPE)  # noqa: E721
-        graphene_type = find_graphene_type(native_type, field, registry)
+        graphene_type = find_graphene_type(
+            native_type, field, registry, parent_type=parent_type, model=model
+        )
         return graphene_type
 
     # Otherwise, we use a little metaprogramming -- create our own unique
     # subclass of graphene.Union that knows its constituent Graphene types
-    parent_types = tuple(find_graphene_type(x, field, registry) for x in inner_types)
+    parent_types = tuple(
+        find_graphene_type(x, field, registry, parent_type=parent_type, model=model)
+        for x in inner_types
+    )
     internal_meta_cls = type("Meta", (), {"types": parent_types})
 
     union_cls = type(

--- a/graphene_pydantic/converters.py
+++ b/graphene_pydantic/converters.py
@@ -157,7 +157,8 @@ def find_graphene_type(
             raise ConversionError(
                 "Don't know how to convert the Pydantic field "
                 f"{field!r} ({field.type_}), could not resolve "
-                "the forward reference."
+                "the forward reference. Did you call `resolve_placeholders()`? "
+                "See the README for more on forward references."
             )
         module_ns = sys.modules[sibling.__module__].__dict__
         resolved = type_._evaluate(module_ns, None)

--- a/graphene_pydantic/registry.py
+++ b/graphene_pydantic/registry.py
@@ -16,6 +16,14 @@ def assert_is_pydantic_object_type(obj_type: T.Type["PydanticObjectType"]):
         raise TypeError(f"Expected PydanticObjectType, but got: {obj_type!r}")
 
 
+class Placeholder:
+    def __init__(self, model: T.Type[BaseModel]):
+        self.model = model
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}({self.model})"
+
+
 class Registry:
     """Hold information about Pydantic models and how they (and their fields) map to Graphene types."""
 
@@ -35,8 +43,17 @@ class Registry:
     def get_type_for_model(self, model: T.Type[BaseModel]) -> "PydanticObjectType":
         return self._registry.get(model)
 
+    def add_placeholder_for_model(self, model: T.Type[BaseModel]):
+        if model in self._registry:
+            return
+        self._registry[model] = Placeholder(model)
+
     def register_object_field(
-        self, obj_type: T.Type["PydanticObjectType"], field_name: str, obj_field: Field
+        self,
+        obj_type: T.Type["PydanticObjectType"],
+        field_name: str,
+        obj_field: Field,
+        model: T.Type[BaseModel] = None,
     ):
         assert_is_pydantic_object_type(obj_type)
 

--- a/tests/test_forward_refs.py
+++ b/tests/test_forward_refs.py
@@ -1,0 +1,107 @@
+import typing as T
+import uuid
+
+import pydantic
+import graphene
+
+from graphene_pydantic import PydanticObjectType
+
+
+class FooModel(pydantic.BaseModel):
+    id: uuid.UUID
+    name: str
+    bar: "BarModel" = None
+    baz: T.Optional["BazModel"]
+    some_bars: T.Optional[T.List["BarModel"]]
+
+
+class BazModel(pydantic.BaseModel):
+    name: str
+    bar: "BarModel" = None
+
+
+class BarModel(pydantic.BaseModel):
+    id: uuid.UUID
+    name: str
+    foo: FooModel
+
+
+# deliberately in this order
+BazModel.update_forward_refs()
+
+
+class Foo(PydanticObjectType):
+    class Meta:
+        model = FooModel
+
+
+class Bar(PydanticObjectType):
+    class Meta:
+        model = BarModel
+
+
+class Baz(PydanticObjectType):
+    class Meta:
+        model = BazModel
+
+
+# yes this is deliberately after too
+FooModel.update_forward_refs()
+
+Foo.resolve_placeholders()
+Bar.resolve_placeholders()
+Baz.resolve_placeholders()
+
+
+class Query(graphene.ObjectType):
+    list_foos = graphene.List(Foo)
+
+    def resolve_list_foos(self, info):
+        """Dummy resolver that creates a list of Pydantic objects"""
+        first_foo = FooModel(id=uuid.uuid4(), name="foo")
+        shared_bar = BarModel(id=uuid.uuid4(), name="shared", foo=first_foo)
+        first_foo.bar = shared_bar
+        first_foo.baz = BazModel(name="baz", bar=shared_bar)
+        first_foo.some_bars = [shared_bar]
+        return [
+            first_foo,
+            FooModel(id=uuid.uuid4(), name="baz", bar=shared_bar, maybe_bar=shared_bar),
+            FooModel(id=uuid.uuid4(), name="quux", bar=shared_bar, some_bars=[]),
+        ]
+
+
+def test_query():
+    from graphql.execution.executors.sync import SyncExecutor
+
+    schema = graphene.Schema(query=Query)
+    result = schema.execute(
+        """
+      query {
+        listFoos {
+          id
+          name
+          bar {
+            id
+            name
+            foo {
+              id
+              baz {
+                name
+                bar { id }
+              }
+            }
+          }
+          baz { name }
+          someBars { id }
+        }
+    }
+    """,
+        executor=SyncExecutor(),
+        return_promise=False,
+    )
+
+    assert result.errors is None
+    assert result.data is not None
+    data = result.data
+    assert data["listFoos"][0]["bar"] is not None
+    assert data["listFoos"][0]["bar"]["foo"]["id"] == data["listFoos"][0]["id"]


### PR DESCRIPTION
Some models reference other models that haven't been defined yet, and some models reference each other -- neither of these was supported. This adds support via a `resolve_placeholders()` method, akin to Pydantic's `update_forward_refs()`.

For instance:

``` python
class NodeModel(BaseModel):
    id: int
    name: str
    labels: 'LabelsModel'
    
class LabelsModel(BaseModel):
    node: NodeModel
    labels: typing.List[str]
    
class Node(PydanticObjectType):
    class Meta:
        model = NodeModel
        
class Labels(PydanticObjectType):
    class Meta:
        model = LabelsModel
        

Node.resolve_placeholders()  # make the `labels` field work
Labels.resolve_placeholders()  # make the `node` field work
```

## Upside CLA
- [x] I agree to the [contributor license agreement](CONTRIBUTOR_LICENSE_AGREEMENT.md)